### PR TITLE
fix the forced extra blank line after included sections

### DIFF
--- a/tools/python/markdown-pp-master/MarkdownPP/Modules/Include.py
+++ b/tools/python/markdown-pp-master/MarkdownPP/Modules/Include.py
@@ -102,7 +102,7 @@ class Include(Module):
                 linenum += 1
 
             # add a blank line to ensure new headings are correctly separated from previous text
-            data.append('\n')
+            data.append("\n\n")
             return data
 
         except (IOError, OSError) as exc:


### PR DESCRIPTION
This is to avoid the case where sections without a blank line at the end get create a continuous block of text with the next document part, changing the structure of the markup.